### PR TITLE
CONTRIB-3969 remove unused query parameters

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -76,6 +76,8 @@ if ($newreport = $mform->get_data()) {
             unset($newreport->{$formparam});
         }
         $newreport->queryparams = serialize($queryparams);
+    } else {
+        $newreport->queryparams = '';
     }
 
     if ($id) {


### PR DESCRIPTION
This unsets queryparams in the database if the user has removed it from the interface.
