### PR TITLE
Give an indication of number of reports available in each category

### DIFF
--- a/index.php
+++ b/index.php
@@ -65,7 +65,6 @@ foreach ($categories as $category) {
     }
     $linkhref = new moodle_url('/report/customsql/index.php', $params);
     $link = html_writer::link($linkhref, $category->name, array('class' => 'categoryname'));
-    echo $OUTPUT->heading($link);
 
     $manualreports = $DB->get_records('report_customsql_queries',
             array('runable' => 'manual', 'categoryid' => $category->id), 'displayname');
@@ -76,6 +75,8 @@ foreach ($categories as $category) {
     $scheduledreports = $DB->get_records_select('report_customsql_queries',
             "(runable = ? OR runable = ?) AND categoryid = ?",
             array('weekly', 'monthly', $category->id), 'id');
+
+    echo $OUTPUT->heading($link . ' ('.count($manualreports).'/'.count($dailyreports).'/'.count($scheduledreports).')');
 
     echo html_writer::start_div('csql_category_reports');
     if (empty($manualreports) && empty($scheduledreports) && empty($dailyreports)) {


### PR DESCRIPTION
![query_count_in_header](https://f.cloud.github.com/assets/1704017/2093573/3858f018-8ebb-11e3-8638-dc924fa887fa.png)

Just a quick change to give an indication of the number of queries in each category.

Not sure of the etiquette on pull requests, but, wanted to send this back because I love this report plugin.  Thanks!
