### PR TITLE
Possible fix for issue with start_div and end_div in Moodle 2.4.6

### DIFF
--- a/index.php
+++ b/index.php
@@ -57,7 +57,7 @@ foreach ($categories as $category) {
     // Are we showing this cat? Default is hidden.
     $show = $category->id == $showcat && $category->id != $hidecat ? 'shown' : 'hidden';
 
-    echo html_writer::start_div('csql_category csql_category' . $show);
+    echo html_writer::start_tag('div', array('class'=>'csql_category csql_category' . $show));
     if ($category->id == $showcat) {
         $params = array('hidecat' => $category->id);
     } else {
@@ -77,7 +77,7 @@ foreach ($categories as $category) {
             "(runable = ? OR runable = ?) AND categoryid = ?",
             array('weekly', 'monthly', $category->id), 'id');
 
-    echo html_writer::start_div('csql_category_reports');
+    echo html_writer::start_tag('div', array('class'=>'csql_category_reports'));
     if (empty($manualreports) && empty($scheduledreports) && empty($dailyreports)) {
         echo $OUTPUT->heading(get_string('availablereports', 'report_customsql'), 3).
         html_writer::tag('p', get_string('noreportsavailable', 'report_customsql'));
@@ -98,8 +98,8 @@ foreach ($categories as $category) {
             report_customsql_print_reports($scheduledreports);
         }
     }
-    echo html_writer::end_div();
-    echo html_writer::end_div();
+    echo html_writer::end_tag('div');
+    echo html_writer::end_tag('div');
 }
 
 if (has_capability('report/customsql:definequeries', $context)) {


### PR DESCRIPTION
When testing this latest of the customsql report with version 2.4.6 of Moodle, I was presented with an empty page where I'd normally have seen all my ad-hoc queries.  Imagine my surprise!  

In reviewing my PHP logs, I see the following:

PHP Fatal error:  Call to undefined method html_writer::start_div() in /root/path/to/moodle/report/customsql/index.php on line 60

Running a Grep on the source looking for html_writer::start_div only returns the two instances found in the index.php file for this custom report.  

Replacing the start_div with start_tag and end_div with end_tag appears to have corrected it on my dev instance and I wanted to share.  

FWIW, I really like addition of categories!  Thanks for your hard work!  If we ever meet at a Moot, beers on me (:beers:).
