### PR TITLE
Fix problem where the description field cannot be edited.

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -76,6 +76,9 @@ if ($newreport = $mform->get_data()) {
         $newreport->singlerow = 0;
     }
 
+    // Unwrap description text value saved in "editor" field type.
+    $newreport->description = $newreport->description['text'];
+
     // Pick up named parameters into serialised array.
     if ($queryparams) {
         foreach ($queryparams as $queryparam => $formparam) {
@@ -116,6 +119,8 @@ echo $OUTPUT->header().
      $OUTPUT->heading(get_string('editingareport', 'report_customsql'));
 
 if ($report) {
+    // Wrap description value as needed by "editor" field type.
+    $report->description = array('text' => $report->description);
     $mform->set_data($report);
 }
 


### PR DESCRIPTION
I found that I could not edit the description field of custom SQL reports. The "editor" type of form field seems to require a wrapper around the text value that the prior "htmleditor" did not need, so I added code to wrap and unwrap the description value during editing. It works for me now.