### PR TITLE
CustomSQL-Added Expand All/Collapse All link to list of reports.

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,6 +53,36 @@ if (!$showcat && count($categories) == 1) {
 admin_externalpage_setup('report_customsql');
 echo $OUTPUT->header();
 
+// Show the Expand all / Collapse all
+$content = "
+<script>
+$(document).ready(function() {
+    $('.collapseexpand').click(function() {
+        if ($('.csql_categoryhidden').length > 0) { // There is at least one collapsed category section.
+            $('.csql_category').removeClass('csql_categoryhidden');
+            $('.csql_category').addClass('csql_categoryshown');
+            $(this).text('". get_string('collapseall')."');
+        } else {                                    // All category sections are expanded
+            $('.csql_category').removeClass('csql_categoryshown');
+            $('.csql_category').addClass('csql_categoryhidden');
+            $(this).text('". get_string('expandall')."');
+        }
+    });
+    $('.csql_category').click(function() {
+        if ($('.csql_categoryhidden').length > 0) { // There is at least one collapsed category section.
+            $('.collapseexpand').text('". get_string('expandall')."');
+        } else {
+            $('.collapseexpand').text('". get_string('collapseall')."');
+        }
+    });
+});
+</script>
+";
+$content .= html_writer::start_tag('div', array('class' => 'collapsible-actions'));
+$content .= html_writer::link('#', get_string('expandall'), array('class' => 'collapseexpand'));
+$content .= html_writer::end_tag('div');
+echo $content;
+
 foreach ($categories as $category) {
     // Are we showing this cat? Default is hidden.
     $show = $category->id == $showcat && $category->id != $hidecat ? 'shown' : 'hidden';


### PR DESCRIPTION
When you have a lot of reports, the list can get pretty long. This adds a new Expand/Collapse link to the list of reports and enable users to just expand the section they are looking for. We have over 130 reports in this list on our own site.

Signed-off-by: Michael Milette michael.milete@instruxmedia.com
