### PR TITLE
CustomSQL-FixFirstTimeRunError - Fix undefined $report->lastrun error

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -330,7 +330,7 @@ function report_customsql_print_reports_for($reports, $type) {
 }
 
 function report_customsql_time_note($report, $tag) {
-    if ($report->lastrun) {
+    if (isset($report->lastrun) && $report->lastrun) {
         $a = new stdClass;
         $a->lastrun = userdate($report->lastrun);
         $a->lastexecutiontime = $report->lastexecutiontime / 1000;


### PR DESCRIPTION
This fixes an issue that appears, with debugging set to developer mode, when you run a report for the first time because $report->lastrun was never previously set.

Signed-off-by: Michael Milette <michael.milete@instruxmedia.com>