### PR TITLE
Add new output placeholders

### DIFF
--- a/lang/en/report_customsql.php
+++ b/lang/en/report_customsql.php
@@ -115,7 +115,7 @@ $string['querynote'] = '<ul>
 <li>For scheduled reports, the tokens <tt>%%STARTTIME%%</tt> and <tt>%%ENDTIME%%</tt> are replaced by the Unix timestamp at the start and end of the reporting week/month in the query before it is executed.</li>
 <li>You can put parameters into the SQL using named placeholders, for example <tt>:parameter_name</tt>. Then, when the report is run, the user can enter values for the parameters to use when running the query.</li>
 <li>If the <tt>:parameter_name</tt> starts or ends with the characters <tt>date</tt> then a date-time selector will be used to input that value, otherwise a plain text-box will be used.</li>
-<li>You cannot use the characters <tt>:</tt> or <tt>?</tt> in strings in your query. If you need them, you can use <tt>CHR(58)</tt> and <tt>CHR(63)</tt> respectively, along with string concatenation. (It is <tt>CHR</tt> for Postgres or Oracle, <tt>CHAR</tt> for MySQL or SQL server.)</li>
+<li>You cannot use the characters <tt>:</tt> or <tt>?</tt> in strings in your query. If you need them, you can use the tokens <tt>%%C%%</tt> and <tt>%%Q%%</tt> respectively.</li>
 </ul>';
 $string['queryparameters'] = 'Query parameters';
 $string['queryparams'] = 'Please enter default values for the query parameters.';

--- a/locallib.php
+++ b/locallib.php
@@ -351,11 +351,18 @@ function report_customsql_pretify_column_names($row) {
     return $colnames;
 }
 
+/**
+ * Writes a CSV row and replaces placeholders.
+ * @param resource $handle the file pointer
+ * @param array $data a data row
+ */
 function report_customsql_write_csv_row($handle, $data) {
     global $CFG;
     $escapeddata = array();
     foreach ($data as $value) {
         $value = str_replace('%%WWWROOT%%', $CFG->wwwroot, $value);
+        $value = str_replace('%%Q%%', '?', $value);
+        $value = str_replace('%%C%%', ':', $value);
         $escapeddata[] = '"'.str_replace('"', '""', $value).'"';
     }
     fwrite($handle, implode(',', $escapeddata)."\r\n");


### PR DESCRIPTION
This request adds two new placeholder tokens, `%%C%%` and `%%Q%%`, for the colon and question mark. This simplifies adding those for outputting and eliminates the need to maintain separate MySQL and Postgres reports where those characters are used.