### PR TITLE
Override defined constants in Moodle's config.php

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -24,8 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-define('REPORT_CUSTOMSQL_MAX_RECORDS', 5000);
-define('REPORT_CUSTOMSQL_START_OF_WEEK', 6); // Saturday.
+if (!defined('REPORT_CUSTOMSQL_MAX_RECORDS')) {
+    define('REPORT_CUSTOMSQL_MAX_RECORDS', 5000);
+}
+if (!defined('REPORT_CUSTOMSQL_START_OF_WEEK')) {
+    define('REPORT_CUSTOMSQL_START_OF_WEEK', 6); // Saturday.
+}
 
 function report_customsql_execute_query($sql, $params = null,
         $limitnum = REPORT_CUSTOMSQL_MAX_RECORDS) {


### PR DESCRIPTION
This pull request makes it possible to modify the maximum row limit and first day of the week constants by adding DEFINE lines to Moodle's config.php instead of modifying the plugin's locallib.php file every time an update is installed. See #30 for more details.