### PR TITLE
Maximum row limit handled from administration

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -30,8 +30,7 @@ defined('MOODLE_INTERNAL') || die();
  * @param string $oldversion the version we are upgrading from.
  * @return bool true on success.
  */
-function xmldb_report_customsql_upgrade($oldversion)
-{
+function xmldb_report_customsql_upgrade($oldversion) {
     global $CFG, $DB;
 
     $dbman = $DB->get_manager();
@@ -75,18 +74,10 @@ function xmldb_report_customsql_upgrade($oldversion)
     }
 
     if ($oldversion < 2013062300) {
-        require_once $CFG->dirroot . '/report/customsql/locallib.php';
+        require_once($CFG->dirroot . '/report/customsql/locallib.php');
         $table = new xmldb_table('report_customsql_queries');
-        $field = new xmldb_field(
-            'querylimit',
-            XMLDB_TYPE_INTEGER,
-            '10',
-            XMLDB_UNSIGNED,
-                XMLDB_NOTNULL,
-            null,
-            report_customsql_get_maximum_row_limit(),
-            'queryparams'
-        );
+        $field = new xmldb_field('querylimit', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED,
+                XMLDB_NOTNULL, null, report_customsql_get_maximum_row_limit(), 'queryparams');
 
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
@@ -104,7 +95,7 @@ function xmldb_report_customsql_upgrade($oldversion)
         $table->add_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, null);
 
         // Adding key to table report_customsql_categories.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
 
         // Conditionally launch create table for report_customsql_categories.
         if (!$dbman->table_exists($table)) {
@@ -121,13 +112,13 @@ function xmldb_report_customsql_upgrade($oldversion)
         }
 
         // Add key (for the new field just added).
-        $key = new xmldb_key('categoryid', XMLDB_KEY_FOREIGN, ['categoryid'], 'report_customsql_categories', ['id']);
+        $key = new xmldb_key('categoryid', XMLDB_KEY_FOREIGN, array('categoryid'), 'report_customsql_categories', array('id'));
         $dbman->add_key($table, $key);
 
         // Create the default 'Miscellaneous' category.
         $category = new stdClass();
         $category->name = get_string('defaultcategory', 'report_customsql');
-        if (!$DB->record_exists('report_customsql_categories', ['name' => $category->name])) {
+        if (!$DB->record_exists('report_customsql_categories', array('name' => $category->name))) {
             $category->id = $DB->insert_record('report_customsql_categories', $category);
         }
         // Update the existing query category ids, to move them into this category.
@@ -140,18 +131,10 @@ function xmldb_report_customsql_upgrade($oldversion)
 
     // Repeat upgrade step that might have got missed on some branches.
     if ($oldversion < 2014020300) {
-        require_once $CFG->dirroot . '/report/customsql/locallib.php';
+        require_once($CFG->dirroot . '/report/customsql/locallib.php');
         $table = new xmldb_table('report_customsql_queries');
-        $field = new xmldb_field(
-            'querylimit',
-            XMLDB_TYPE_INTEGER,
-            '10',
-            XMLDB_UNSIGNED,
-                XMLDB_NOTNULL,
-            null,
-            report_customsql_get_maximum_row_limit(),
-            'queryparams'
-        );
+        $field = new xmldb_field('querylimit', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED,
+                XMLDB_NOTNULL, null, report_customsql_get_maximum_row_limit(), 'queryparams');
 
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -24,20 +24,19 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-
 /**
  * Upgrade code for report_customsql.
  *
  * @param string $oldversion the version we are upgrading from.
  * @return bool true on success.
  */
-function xmldb_report_customsql_upgrade($oldversion) {
+function xmldb_report_customsql_upgrade($oldversion)
+{
     global $CFG, $DB;
 
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2012011900) {
-
         // Add field to report_customsql_queries.
         $table = new xmldb_table('report_customsql_queries');
         if ($dbman->table_exists($table)) {
@@ -52,11 +51,9 @@ function xmldb_report_customsql_upgrade($oldversion) {
     }
 
     if ($oldversion < 2012092400) {
-
         // Add fields to report_customsql_queries.
         $table = new xmldb_table('report_customsql_queries');
         if ($dbman->table_exists($table)) {
-
             // Define and add the field 'at'.
             $field = new xmldb_field('at', XMLDB_TYPE_CHAR, '16', null, XMLDB_NOTNULL, null, null, 'singlerow');
             if (!$dbman->field_exists($table, $field)) {
@@ -78,10 +75,18 @@ function xmldb_report_customsql_upgrade($oldversion) {
     }
 
     if ($oldversion < 2013062300) {
-        require_once($CFG->dirroot . '/report/customsql/locallib.php');
+        require_once $CFG->dirroot . '/report/customsql/locallib.php';
         $table = new xmldb_table('report_customsql_queries');
-        $field = new xmldb_field('querylimit', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED,
-                XMLDB_NOTNULL, null, REPORT_CUSTOMSQL_MAX_RECORDS, 'queryparams');
+        $field = new xmldb_field(
+            'querylimit',
+            XMLDB_TYPE_INTEGER,
+            '10',
+            XMLDB_UNSIGNED,
+                XMLDB_NOTNULL,
+            null,
+            report_customsql_get_maximum_row_limit(),
+            'queryparams'
+        );
 
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
@@ -91,7 +96,6 @@ function xmldb_report_customsql_upgrade($oldversion) {
     }
 
     if ($oldversion < 2013102400) {
-
         // Define table report_customsql_categories to be created.
         $table = new xmldb_table('report_customsql_categories');
 
@@ -100,7 +104,7 @@ function xmldb_report_customsql_upgrade($oldversion) {
         $table->add_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, null);
 
         // Adding key to table report_customsql_categories.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
 
         // Conditionally launch create table for report_customsql_categories.
         if (!$dbman->table_exists($table)) {
@@ -112,18 +116,18 @@ function xmldb_report_customsql_upgrade($oldversion) {
         $field = new xmldb_field('categoryid', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, null, null, null, 'emailwhat');
 
         // Conditionally launch add field categoryid.
-        if (! $dbman->field_exists($table, $field)) {
+        if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
         // Add key (for the new field just added).
-        $key = new xmldb_key('categoryid', XMLDB_KEY_FOREIGN, array('categoryid'), 'report_customsql_categories', array('id'));
+        $key = new xmldb_key('categoryid', XMLDB_KEY_FOREIGN, ['categoryid'], 'report_customsql_categories', ['id']);
         $dbman->add_key($table, $key);
 
         // Create the default 'Miscellaneous' category.
         $category = new stdClass();
         $category->name = get_string('defaultcategory', 'report_customsql');
-        if (!$DB->record_exists('report_customsql_categories', array('name' => $category->name))) {
+        if (!$DB->record_exists('report_customsql_categories', ['name' => $category->name])) {
             $category->id = $DB->insert_record('report_customsql_categories', $category);
         }
         // Update the existing query category ids, to move them into this category.
@@ -136,10 +140,18 @@ function xmldb_report_customsql_upgrade($oldversion) {
 
     // Repeat upgrade step that might have got missed on some branches.
     if ($oldversion < 2014020300) {
-        require_once($CFG->dirroot . '/report/customsql/locallib.php');
+        require_once $CFG->dirroot . '/report/customsql/locallib.php';
         $table = new xmldb_table('report_customsql_queries');
-        $field = new xmldb_field('querylimit', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED,
-                XMLDB_NOTNULL, null, REPORT_CUSTOMSQL_MAX_RECORDS, 'queryparams');
+        $field = new xmldb_field(
+            'querylimit',
+            XMLDB_TYPE_INTEGER,
+            '10',
+            XMLDB_UNSIGNED,
+                XMLDB_NOTNULL,
+            null,
+            report_customsql_get_maximum_row_limit(),
+            'queryparams'
+        );
 
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
@@ -149,7 +161,6 @@ function xmldb_report_customsql_upgrade($oldversion) {
     }
 
     if ($oldversion < 2015062900) {
-
         // Define field descriptionformat to be added to report_customsql_queries.
         $table = new xmldb_table('report_customsql_queries');
         $field = new xmldb_field('descriptionformat', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '1', 'description');
@@ -164,7 +175,6 @@ function xmldb_report_customsql_upgrade($oldversion) {
     }
 
     if ($oldversion < 2016011800) {
-
         // Define field customdir to be added to report_customsql_queries.
         $table = new xmldb_table('report_customsql_queries');
         $field = new xmldb_field('customdir', XMLDB_TYPE_CHAR, '255', null, null, null, null, 'categoryid');

--- a/edit_form.php
+++ b/edit_form.php
@@ -82,7 +82,7 @@ class report_customsql_edit_form extends moodleform {
 
         $mform->addElement('text', 'querylimit', get_string('querylimit', 'report_customsql'));
         $mform->setType('querylimit', PARAM_INT);
-        $mform->setDefault('querylimit', REPORT_CUSTOMSQL_MAX_RECORDS);
+        $mform->setDefault('querylimit', report_customsql_get_maximum_row_limit());
         $mform->addRule('querylimit', get_string('requireint', 'report_customsql'),
                         'numeric', null, 'client');
 
@@ -204,9 +204,9 @@ class report_customsql_edit_form extends moodleform {
             }
         }
 
-        // Check querylimit in range 1 .. REPORT_CUSTOMSQL_MAX_RECORDS.
-        if (empty($data['querylimit']) || $data['querylimit'] > REPORT_CUSTOMSQL_MAX_RECORDS) {
-            $errors['querylimit'] = get_string('querylimitrange', 'report_customsql', REPORT_CUSTOMSQL_MAX_RECORDS);
+        // Check querylimit in range 1 .. report_customsql_get_maximum_row_limit().
+        if (empty($data['querylimit']) || $data['querylimit'] > report_customsql_get_maximum_row_limit()) {
+            $errors['querylimit'] = get_string('querylimitrange', 'report_customsql', report_customsql_get_maximum_row_limit());
         }
 
         if (!empty($data['customdir'])) {

--- a/lang/en/report_customsql.php
+++ b/lang/en/report_customsql.php
@@ -148,3 +148,5 @@ $string['weeklyheader'] = 'Weekly';
 $string['weeklyheader_help'] = 'These queries are automatically run on the first day of each week, to report on the previous week. These links let you view the results that has already been accumulated.';
 $string['whocanaccess'] = 'Who can access this query';
 $string['privacy:metadata'] = 'The Ad-hoc database queries plugin does not store any personal data.';
+$string['maxrowlimit'] = 'Maximum results';
+$string['maxrowlimit_help'] = 'The maximum number of results returned.';

--- a/locallib.php
+++ b/locallib.php
@@ -24,11 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-define('REPORT_CUSTOMSQL_MAX_RECORDS', 5000);
 define('REPORT_CUSTOMSQL_START_OF_WEEK', 6); // Saturday.
 
 function report_customsql_execute_query($sql, $params = null,
-        $limitnum = REPORT_CUSTOMSQL_MAX_RECORDS) {
+        $limitnum) {
     global $CFG, $DB;
 
     $sql = preg_replace('/\bprefix_(?=\w+)/i', $CFG->prefix, $sql);
@@ -78,7 +77,7 @@ function report_customsql_generate_csv($report, $timenow) {
     $sql = report_customsql_prepare_sql($report, $timenow);
 
     $queryparams = !empty($report->queryparams) ? unserialize($report->queryparams) : array();
-    $querylimit  = !empty($report->querylimit) ? $report->querylimit : REPORT_CUSTOMSQL_MAX_RECORDS;
+    $querylimit  = !empty($report->querylimit) ? $report->querylimit : report_customsql_get_maximum_row_limit();
     $rs = report_customsql_execute_query($sql, $queryparams, $querylimit);
 
     $csvfilenames = array();
@@ -700,4 +699,12 @@ function report_customsql_copy_csv_to_customdir($report, $timenow, $csvfilename 
 function report_customsql_plain_text_report_name($report) {
     return format_string($report->displayname, true,
             ['context' => \context_system::instance()]);
+}
+
+/**
+ * Get the maximum number of results returned for a query defined in admin settings
+ */
+function report_customsql_get_maximum_row_limit()
+{
+    return get_config('report_customsql', 'maxrowlimit');
 }

--- a/locallib.php
+++ b/locallib.php
@@ -26,8 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 define('REPORT_CUSTOMSQL_START_OF_WEEK', 6); // Saturday.
 
-function report_customsql_execute_query($sql, $params = null,
-        $limitnum) {
+function report_customsql_execute_query($sql, $params = null, $limitnum) {
     global $CFG, $DB;
 
     $sql = preg_replace('/\bprefix_(?=\w+)/i', $CFG->prefix, $sql);
@@ -704,7 +703,6 @@ function report_customsql_plain_text_report_name($report) {
 /**
  * Get the maximum number of results returned for a query defined in admin settings
  */
-function report_customsql_get_maximum_row_limit()
-{
+function report_customsql_get_maximum_row_limit() {
     return get_config('report_customsql', 'maxrowlimit');
 }

--- a/settings.php
+++ b/settings.php
@@ -24,9 +24,18 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$settings = null;
-
-$ADMIN->add('reports', new admin_externalpage('report_customsql',
+$ADMIN->add('reports', new admin_externalpage(
+    'report_customsql',
         get_string('pluginname', 'report_customsql'),
         new moodle_url('/report/customsql/index.php'),
-        'report/customsql:view'));
+        'report/customsql:view'
+));
+
+if ($ADMIN->fulltree) {
+    $settings->add(new admin_setting_configtext(
+        'report_customsql/maxrowlimit',
+        get_string('maxrowlimit', 'report_customsql'),
+        get_string('maxrowlimit_help', 'report_customsql'),
+        '5000'
+     ));
+}

--- a/settings.php
+++ b/settings.php
@@ -26,10 +26,9 @@ defined('MOODLE_INTERNAL') || die();
 
 $ADMIN->add('reports', new admin_externalpage(
     'report_customsql',
-        get_string('pluginname', 'report_customsql'),
-        new moodle_url('/report/customsql/index.php'),
-        'report/customsql:view'
-));
+    get_string('pluginname', 'report_customsql'),
+    new moodle_url('/report/customsql/index.php'),
+    'report/customsql:view'));
 
 if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext(

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018090600;
-$plugin->requires = 2017111300;
+$plugin->version   = 2018090600;
+$plugin->requires  = 2017111300;
 $plugin->component = 'report_customsql';
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '3.5 for Moodle 3.4+';
+$plugin->maturity  = MATURITY_STABLE;
+$plugin->release   = '3.5 for Moodle 3.4+';
 
 $plugin->outestssufficient = true;

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018080900;
-$plugin->requires  = 2017111300;
+$plugin->version = 2018090600;
+$plugin->requires = 2017111300;
 $plugin->component = 'report_customsql';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '3.5 for Moodle 3.4+';
+$plugin->maturity = MATURITY_STABLE;
+$plugin->release = '3.5 for Moodle 3.4+';
 
 $plugin->outestssufficient = true;

--- a/view.php
+++ b/view.php
@@ -166,9 +166,9 @@ if (is_null($csvtimestamp)) {
         fclose($handle);
         echo html_writer::table($table);
 
-        if ($count >= REPORT_CUSTOMSQL_MAX_RECORDS) {
+        if ($count >= report_customsql_get_maximum_row_limit()) {
             echo html_writer::tag('p', get_string('recordlimitreached', 'report_customsql',
-                                                  REPORT_CUSTOMSQL_MAX_RECORDS),
+                                                  report_customsql_get_maximum_row_limit()),
                                                   array('class' => 'admin_note'));
         }
         echo report_customsql_time_note($report, 'p').


### PR DESCRIPTION
Hello,

As you mentioned in previous closed PR for this matter, I simply :

- Added a new admin setting for this plugin enabling users to set the maximum row limit for query results
- Added a new function in `locallib.php` only fetching the row limit from administration config
- Replace your constant with this function call

My configuration of VS Code might have changed some indentation for several files though...