### PR TITLE
Convert fully to core Message API.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ matrix:
 
     - php: 7.1
       env:
+      - MOODLE_BRANCH=MOODLE_36_STABLE
+      - DB=mysqli
+
+    - php: 7.1
+      env:
       - MOODLE_BRANCH=MOODLE_35_STABLE
       - DB=mysqli
 

--- a/db/messages.php
+++ b/db/messages.php
@@ -27,6 +27,10 @@ defined('MOODLE_INTERNAL') || die();
 $messageproviders = array(
     // Notify users on the list who can view repot custimsql.
     'notification' => array(
-        'capability' => 'report/customsql:view'
+        'capability' => 'report/customsql:view',
+
+        'defaults' => array(
+            'email' => MESSAGE_FORCED,
+        ),
     ),
 );

--- a/locallib.php
+++ b/locallib.php
@@ -698,12 +698,12 @@ function report_customsql_get_ready_to_run_daily_reports($timenow) {
 function report_customsql_send_email_notification($recipient, $message) {
 
     // Prepare the message.
-    $eventdata = new stdClass();
+    $eventdata = new \core\message\message();
     $eventdata->component         = 'report_customsql';
     $eventdata->name              = 'notification';
     $eventdata->notification      = 1;
-
-    $eventdata->userfrom          = get_admin();
+    $eventdata->courseid          = SITEID;
+    $eventdata->userfrom          = \core_user::get_support_user();
     $eventdata->userto            = $recipient;
     $eventdata->subject           = $message->subject;
     $eventdata->fullmessage       = $message->fullmessage;


### PR DESCRIPTION
This changes the plugin's ``email_report()`` method to pass an instance of ``\core\message\message`` to ``message_send()``

I added MOODLE_36_STABLE branch to the Travis config, all tests pass in 33, 34, 35, 36 & master branches.

Note that running the new test on current master, without the other changes here, produces the following TypeError (i.e. broken e-mails in upcoming 3.7):

```
$ vendor/bin/phpunit report/customsql/tests/report_test.php 
Moodle 3.7dev+ (Build: 20190406), 9d4f4f0051290d0dc72aaa90d4b9b00f30914529
Php: 7.2.16.1.14.04.1.1, mysqli: 5.6.33-0ubuntu0.14.04.1, OS: Linux 3.13.0-168-generic x86_64
PHPUnit 7.5.7 by Sebastian Bergmann and contributors.

................E                                                 17 / 17 (100%)

Time: 727 ms, Memory: 38.00 MB

There was 1 error:

1) report_customsql_test::test_report_customsql_email_report
TypeError: Argument 1 passed to message_send() must be an instance of core\message\message, instance of stdClass given, called in /home/pholden/Source/moodle-report_customsql/locallib.php on line 714

/home/pholden/Source/moodle/code/lib/messagelib.php:57
/home/pholden/Source/moodle-report_customsql/locallib.php:714
/home/pholden/Source/moodle-report_customsql/locallib.php:655
/home/pholden/Source/moodle-report_customsql/tests/report_test.php:303
/home/pholden/Source/moodle/code/lib/phpunit/classes/advanced_testcase.php:80

To re-run:
 vendor/bin/phpunit "report_customsql_test" /home/pholden/Source/moodle-report_customsql/tests/report_test.php

ERRORS!
Tests: 17, Assertions: 36, Errors: 1.
```

Fixes #42 & #43.