### PR TITLE
Use Firefox in Travis Behat runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ services:
 addons:
   firefox: "47.0.1"
   postgresql: "9.6"
-  apt:
-    packages:
-      - openjdk-8-jre-headless
-      - chromium-chromedriver
 
 cache:
   directories:
@@ -57,4 +53,4 @@ script:
   - moodle-plugin-ci mustache || true # report issues, but don't fail the build.
   - moodle-plugin-ci grunt
   - moodle-plugin-ci phpunit
-  - moodle-plugin-ci behat --profile chrome
+  - moodle-plugin-ci behat


### PR DESCRIPTION
Seems recent branches are breaking during the Behat run ([here](https://travis-ci.org/paulholden/moodle-report_customsql/builds/595827829) & [here](https://travis-ci.org/paulholden/moodle-report_customsql/builds/595855352))

See docs regarding usage of Chrome/ChromeDriver:

https://github.com/blackboard-open-source/moodle-plugin-ci/blob/master/docs/Chrome.md#troubleshooting

Suggestion is to switch back to Firefox.

Specifying a JDK is also now redundant, as one is already pre-installed in the image