### PR TITLE
Feature: Send CSV Report as attachment

### DIFF
--- a/lang/en/report_customsql.php
+++ b/lang/en/report_customsql.php
@@ -71,6 +71,7 @@ $string['editingareport'] = 'Editing an ad-hoc database query';
 $string['editreportx'] = 'Edit query \'{$a}\'';
 $string['emailnumberofrows'] = 'Just the number of rows and the link';
 $string['emailresults'] = 'Put the results in the email body';
+$string['emailattachment'] = 'Attach CSV to email body';
 $string['emailink'] = 'To access the report, click this link: {$a}';
 $string['emailrow'] = 'The report returned {$a} row.';
 $string['emailrows'] = 'The report returned {$a} rows.';

--- a/locallib.php
+++ b/locallib.php
@@ -110,6 +110,7 @@ function report_customsql_generate_csv($report, $timenow) {
     $csvfilenames = array();
     $csvtimestamp = null;
     $count = 0;
+    $file = null;
     foreach ($rs as $row) {
         if (!$csvtimestamp) {
             list($csvfilename, $csvtimestamp) = report_customsql_csv_filename($report, $timenow);
@@ -117,6 +118,19 @@ function report_customsql_generate_csv($report, $timenow) {
 
             if (!file_exists($csvfilename)) {
                 $handle = fopen($csvfilename, 'w');
+                $fs = get_file_storage();
+                $file = $fs->create_file_from_pathname(
+                    [
+                        'contextid' => context_system::instance()->id,
+                        'component' => 'report_customsql',
+                        'filearea' => 'admin_report_customsql',
+                        'itemid' => 0, 
+                        'filepath' => dirname($csvfilename) . '/',
+                        'filename' => basename($csvfilename),
+                    ], 
+                    $csvfilename
+                );
+
                 report_customsql_start_csv($handle, $row, $report);
             } else {
                 $handle = fopen($csvfilename, 'a');

--- a/locallib.php
+++ b/locallib.php
@@ -712,6 +712,22 @@ function report_customsql_get_message($report, $csvfilename) {
     $message->fullmessagehtml   = $fullmessagehtml;
     $message->smallmessage      = null;
 
+    $fs = get_file_storage();
+
+    // Issue using GetFile to fetch the file
+    $file = $fs->get_file(
+        context_system::instance()->id,
+        'report_customsql',
+        'admin_report_customsql',
+        0,
+        dirname($csvfilename) . '/',
+        basename($csvfilename)
+    );
+
+    if($report->emailwhat === 'emailattachment'){
+        $message->attachment = $file;
+    }
+
     return $message;
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -793,6 +793,7 @@ function report_customsql_send_email_notification($recipient, $message) {
     $eventdata->fullmessageformat = $message->fullmessageformat;
     $eventdata->fullmessagehtml   = $message->fullmessagehtml;
     $eventdata->smallmessage      = $message->smallmessage;
+    $eventdata->attachment        = $message->attachment;
 
     return message_send($eventdata);
 }

--- a/locallib.php
+++ b/locallib.php
@@ -281,6 +281,7 @@ function report_customsql_daily_at_options() {
 function report_customsql_email_options() {
     return array('emailnumberofrows' => get_string('emailnumberofrows', 'report_customsql'),
             'emailresults' => get_string('emailresults', 'report_customsql'),
+            'emailattachment' => get_string('emailattachment', 'report_customsql'),
     );
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -579,7 +579,23 @@ function report_customsql_delete_old_temp_files($upto) {
     }
     foreach ($files as $file) {
         if (basename($file) < $comparison) {
-            unlink($file);
+             $fs = get_file_storage();
+
+            $fileinfo = array(
+            'component' => 'report_customsql',
+            'filearea' => 'admin_report_customsql',
+                    'itemid' => 0,
+            'contextid' => context_system::instance()->id,
+            'filepath' => dirname($file) . '/',
+                    'filename' => basename($file));
+
+            $file = $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'],
+                                $fileinfo['itemid'], $fileinfo['filepath'], $fileinfo['filename']);
+
+            // Delete it if it exists
+                if ($file) {
+                    $file->delete();
+                }
             $count += 1;
         }
     }


### PR DESCRIPTION
In Reference to Issue: #55

Hello, 
To add the functionality for CSV attachment to be emailed to the user, we have explored using the File API and Messaging API to create a CSV File and attach it to the email body. 

We were successfully able to add an option for the user, create the CSV File using the File API but the step involving fetching the file to attach always returns 'false'. 

The moodle documentation for "[Read File](https://docs.moodle.org/dev/File_API#Read_file)" states the below which might be the reason the below method does not work.

>This is a way to read a file, equivalent to file_get_contents. Please note your are allowed to do this ONLY from mod/mymodule/* code, it is not acceptable to do this anywhere else. Other code has to use file_browser interface instead.

The Messaging API on the otherhand is able to accept file attachments, this has been added in the code in the PR too. 

Would really appreciate your review. Additionally, for the "Read/Get File", we would love to get any tips or redirection to any alternate moodle functionality that we can use for plugins of type report to fix the missing functionality. 
 