### PR TITLE
Add composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "moodleou-report/customsql",
+    "description": "A Moodle report plugin that lets you easily create simple reports that can be expressed as a single SQL query",
+    "type": "moodle-report",
+    "require": {
+        "composer/installers": "^2.1"
+    }
+}


### PR DESCRIPTION
The type `moodle-report` installers the plugin into the [correct directory when using composer](https://github.com/composer/installers/blob/main/src/Composer/Installers/MoodleInstaller.php#L55).