### PR TITLE
Fix #114 - return empty csv file (with headers) when no results.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/lib.php
+++ b/lib.php
@@ -89,7 +89,7 @@ function report_customsql_pluginfile($course, $cm, $context, $filearea, $args, $
         if ($report->runable !== 'manual') {
             $runtime = $report->lastrun;
         }
-        $csvtimestamp = \report_customsql_generate_csv($report, $runtime);
+        $csvtimestamp = \report_customsql_generate_csv($report, $runtime, true);
     }
     list($csvfilename) = report_customsql_csv_filename($report, $csvtimestamp);
 

--- a/locallib.php
+++ b/locallib.php
@@ -99,10 +99,9 @@ function report_customsql_get_element_type($name) {
 /**
  * Generate customsql csv file.
  *
- * @param stdclass $report - report record from customsql table.
- * @param int $timetimenow - unix timestamp - usually "now()"
- * @param bool $returnheaderwhenempty - if true will return a csv with the header row.
- * @return void
+ * @param stdclass $report report record from customsql table.
+ * @param int $timetimenow unix timestamp - usually "now()"
+ * @param bool $returnheaderwhenempty if true, a CSV file with headers will always be generated, even if there are no results.
  */
 function report_customsql_generate_csv($report, $timenow, $returnheaderwhenempty = false) {
     global $DB;
@@ -141,13 +140,9 @@ function report_customsql_generate_csv($report, $timenow, $returnheaderwhenempty
 
         $data = get_object_vars($row);
 
-        if ($returnheaderwhenempty) {
-            // Ignore a row if it is full of null values.
-            $values = array_unique(array_values($data));
-            if (empty($values) || (count($values) === 1 && $values[0] === null)) {
-                // This is a row with all null values - ignore it.
-                continue;
-            }
+        if ($returnheaderwhenempty && array_unique(array_values($data)) === [null]) {
+            // This is a row with all null values - ignore it.
+            continue;
         }
         foreach ($data as $name => $value) {
             if (report_customsql_get_element_type($name) == 'date_time_selector' &&

--- a/tests/behat/behat_report_customsql.php
+++ b/tests/behat/behat_report_customsql.php
@@ -239,6 +239,28 @@ class behat_report_customsql extends behat_base {
     }
 
     /**
+     * Simulates downloading an empty report to ensure it shows table headers.
+     *
+     * For example:
+     * When downloading the empty custom sql report "Frog" it contains the headers "frogname,freddy"
+     *
+     * @Then /^downloading custom sql report "(?P<REPORT_NAME>[^"]*)" returns a file with headers "([^"]*)"$/
+     * @param string $reportname the name of the report to go to.
+     * @param string $headers the headers that shuold be returned.
+     */
+    public function downloading_custom_sql_report_x_returns_a_file_with_headers(string $reportname, string $headers) {
+        $report = $this->get_report_by_name($reportname);
+        $url = new \moodle_url('/pluginfile.php/1/'.'report_customsql'. '/'.'download'. '/'. $report->id, ['dataformat' => 'csv']);
+
+        $session = $this->getSession()->getCookie('MoodleSession');
+        $filecontent = trim(download_file_content($url, array('Cookie' => 'MoodleSession=' . $session)));
+        $filecontent = core_text::trim_utf8_bom($filecontent);
+        if ($filecontent != $headers) {
+            throw new \Behat\Mink\Exception\ExpectationException("File headers: $filecontent did not match expected: $headers", $this->getSession());
+        }
+    }
+
+    /**
      * Find a report by name and get all the details.
      *
      * @param string $reportname the report name to find.

--- a/tests/behat/report_customsql.feature
+++ b/tests/behat/report_customsql.feature
@@ -76,6 +76,13 @@ Feature: Ad-hoc database queries report
     And I view the "Test query" custom sql report
     Then I should see "This query did not return any data."
 
+  Scenario: Download an Ad-hoc database query that returns no data but includes headers
+    Given the following custom sql report exists:
+      | name     | Test query                               |
+      | querysql | SELECT * FROM {config} WHERE name = '-1' |
+    When I log in as "admin"
+    Then downloading custom sql report "Test query" returns a file with headers "id,name,value"
+
   Scenario: Create an Ad-hoc database queries category
     When I log in as "admin"
     And I navigate to "Reports > Ad-hoc database queries" in site administration


### PR DESCRIPTION
here's a method that allows us to use the plugins normal methods for printing columns in a report by adding a record of null values to the report when the main query is empty.

Hopefully it makes sense - seems to work cross db for me but would be good to test further - I'll see if we can get some other folks to test too.