### PR TITLE
Remove underline on mouse hover.

### DIFF
--- a/templates/category_query.mustache
+++ b/templates/category_query.mustache
@@ -54,14 +54,10 @@
     {{#canedit}}
         <span class="admin_note">{{#str}}availableto, report_customsql, {{capability}} {{/str}}</span>
         {{#editbutton}}
-            <a href="{{url}}" title="{{#str}}editreportx, report_customsql, {{displayname}}{{/str}}">
-                {{{img}}}
-            </a>
+            <a href="{{url}}" title="{{#str}}editreportx, report_customsql, {{displayname}}{{/str}}">{{{img}}}</a>
         {{/editbutton}}
         {{#deletebutton}}
-            <a href="{{url}}" title="{{#str}}deletereportx, report_customsql, {{{displayname}}}{{/str}}">
-                {{{img}}}
-            </a>
+            <a href="{{url}}" title="{{#str}}deletereportx, report_customsql, {{{displayname}}}{{/str}}">{{{img}}}</a>
         {{/deletebutton}}
     {{/ canedit }}
 </p>


### PR DESCRIPTION
This gets rid of this unneeded underline when hovering in the list of queries.
<img width="83" alt="image" src="https://user-images.githubusercontent.com/377279/231450039-dc4b6f82-39ed-4506-933b-e92a8501d121.png">
