### PR TITLE
Phpunit fix for running tests in separate process

### DIFF
--- a/tests/external/external_get_users_test.php
+++ b/tests/external/external_get_users_test.php
@@ -31,6 +31,7 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @category  external
  * @copyright 2020 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @runTestsInSeparateProcesses
  */
 class external_get_users_test extends \externallib_advanced_testcase {
 


### PR DESCRIPTION
To fix the following error messages:

``` 
1) report_customsql\external\external_get_users_test::test_get_users_site_config
coding_exception: Coding error detected, it must be fixed by a programmer: When including this file for a unit test, the test must be run in an isolated process. See the PHPUnit @runInSeparateProcess and @runTestsInSeparateProcesses annotations.

/var/www/html/lib/setuplib.php:2204
/var/www/html/lib/externallib.php:35
/var/www/html/report/customsql/classes/external/get_users.php:22
/var/www/html/lib/classes/component.php:144
/var/www/html/report/customsql/tests/external/external_get_users_test.php:73
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

2) report_customsql\external\external_get_users_test::test_get_users_site_viewreports
Error: Class "report_customsql\external\get_users" not found

/var/www/html/report/customsql/tests/external/external_get_users_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

3) report_customsql\external\external_get_users_test::test_get_users_customsql_view
Error: Class "report_customsql\external\get_users" not found

/var/www/html/report/customsql/tests/external/external_get_users_test.php:116
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

4) report_customsql\external\external_get_users_test::test_get_users_serch_without_admins
Error: Class "report_customsql\external\get_users" not found

/var/www/html/report/customsql/tests/external/external_get_users_test.php:148
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

5) report_customsql\external\external_get_users_test::test_get_users_serch_with_admin
Error: Class "report_customsql\external\get_users" not found

/var/www/html/report/customsql/tests/external/external_get_users_test.php:166
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94
```