### PR TITLE
Issue #130: Fix reset() call on object

### DIFF
--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -81,7 +81,7 @@ class privacy_test extends \core_privacy\tests\provider_testcase {
         $subcontext = [
             get_string('privacy:metadata:reportcustomsqlqueries', 'report_customsql')
         ];
-        $data = $writer->get_data($subcontext);
+        $data = (array) $writer->get_data($subcontext);
         $this->assertEquals('Report of user 1', reset($data)['displayname']);
     }
 


### PR DESCRIPTION
Closes #130 

Before:
```
1) report_customsql\privacy_test::test_export_user_data
This test printed output: 
Deprecated: reset(): Calling reset() on an object is deprecated in /var/www/site/report/customsql/tests/privacy_test.php on line 85
```
After:
```
root@567c0783abc4:/var/www/site# phpu --filter="report_customsql"     
Moodle 4.1.5+ (Build: 20230908), 877e33ff76d16062213c3792b53ff345b2c9556d
Php: 8.1.2.1.2.13, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.1.0-1019-oem x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

.........................................................         57 / 57 (100%)

Time: 00:03.078, Memory: 388.00 MB

OK (57 tests, 188 assertions)
```