### PR TITLE
Issue 141 fix external get users not found

### DIFF
--- a/classes/external/get_users.php
+++ b/classes/external/get_users.php
@@ -21,6 +21,13 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->libdir . '/externallib.php');
 
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_value;
+use core_external\external_description;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+
 /**
  * Web service used by form autocomplete to get a list of users with a given capability.
  *
@@ -28,16 +35,16 @@ require_once($CFG->libdir . '/externallib.php');
  * @copyright 2020 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class get_users extends \external_api {
+class get_users extends external_api {
     /**
      * Parameter declaration.
      *
      * @return \external_function_parameters Parameters
      */
-    public static function execute_parameters(): \external_function_parameters {
-        return new \external_function_parameters([
-            'query' => new \external_value(PARAM_RAW, 'Contents of the search box.'),
-            'capability' => new \external_value(PARAM_CAPABILITY, 'Return only users with this capability in the system context.'),
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'query' => new external_value(PARAM_RAW, 'Contents of the search box.'),
+            'capability' => new external_value(PARAM_CAPABILITY, 'Return only users with this capability in the system context.'),
         ]);
     }
 
@@ -138,14 +145,14 @@ class get_users extends \external_api {
      *
      * @return \external_description Result type
      */
-    public static function execute_returns(): \external_description {
-        return new \external_multiple_structure(
-            new \external_single_structure([
-                'id' => new \external_value(PARAM_INT, 'User id.'),
-                'fullname' => new \external_value(PARAM_RAW, 'User full name.'),
-                'identity' => new \external_value(PARAM_RAW, 'Additional user identifying info.'),
-                'hasidentity' => new \external_value(PARAM_BOOL, 'Whether identity is non-blank.'),
-                'profileimageurlsmall' => new \external_value(PARAM_RAW, 'URL of the user profile image.'),
+    public static function execute_returns(): external_description {
+        return new external_multiple_structure(
+            new external_single_structure([
+                'id' => new external_value(PARAM_INT, 'User id.'),
+                'fullname' => new external_value(PARAM_RAW, 'User full name.'),
+                'identity' => new external_value(PARAM_RAW, 'Additional user identifying info.'),
+                'hasidentity' => new external_value(PARAM_BOOL, 'Whether identity is non-blank.'),
+                'profileimageurlsmall' => new external_value(PARAM_RAW, 'URL of the user profile image.'),
             ]));
     }
 }

--- a/tests/external/external_get_users_test.php
+++ b/tests/external/external_get_users_test.php
@@ -23,6 +23,7 @@ global $CFG;
 
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
+use core_external\external_api;
 
 /**
  * Tests for the get_users web service.
@@ -31,6 +32,9 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @category  external
  * @copyright 2020 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @runTestsInSeparateProcesses
+ *
  */
 class external_get_users_test extends \externallib_advanced_testcase {
 
@@ -52,7 +56,7 @@ class external_get_users_test extends \externallib_advanced_testcase {
 
         // Create some users.
         $DB->update_record('user', (object)
-                ['id' => $USER->id, 'firstname' => 'Admin', 'lastname' => 'User']);
+                ['id' => (int) $USER->id, 'firstname' => 'Admin', 'lastname' => 'User']);
         $admin = $DB->get_record('user', ['id' => $USER->id]);
         $manager = $generator->create_user(
                 ['firstname' => 'The', 'lastname' => 'Manager', 'email' => 'manager@example.com']);
@@ -68,10 +72,10 @@ class external_get_users_test extends \externallib_advanced_testcase {
 
     public function test_get_users_site_config() {
         [$admin] = $this->setup_users();
-        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/_s/boost/core/1/u/f2';
+        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/boost/core/1/u/f2';
 
         $result = get_users::execute('', 'moodle/site:config');
-        $result = \external_api::clean_returnvalue(get_users::execute_returns(), $result);
+        $result = external_api::clean_returnvalue(get_users::execute_returns(), $result);
 
         $this->assertEquals([
                 [
@@ -86,10 +90,11 @@ class external_get_users_test extends \externallib_advanced_testcase {
 
     public function test_get_users_site_viewreports() {
         [$admin, $manager] = $this->setup_users();
-        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/_s/boost/core/1/u/f2';
+        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/boost/core/1/u/f2';
 
         $result = get_users::execute('', 'moodle/site:viewreports');
-        $result = \external_api::clean_returnvalue(get_users::execute_returns(), $result);
+        $result = external_api::clean_returnvalue(get_users::execute_returns(), $result);
+
 
         $this->assertEquals([
                 [
@@ -111,10 +116,10 @@ class external_get_users_test extends \externallib_advanced_testcase {
 
     public function test_get_users_customsql_view() {
         [$admin, $manager, $coursecreateor] = $this->setup_users();
-        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/_s/boost/core/1/u/f2';
+        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/boost/core/1/u/f2';
 
         $result = get_users::execute('', 'report/customsql:view');
-        $result = \external_api::clean_returnvalue(get_users::execute_returns(), $result);
+        $result = external_api::clean_returnvalue(get_users::execute_returns(), $result);
 
         $this->assertEquals([
                 [
@@ -143,10 +148,10 @@ class external_get_users_test extends \externallib_advanced_testcase {
 
     public function test_get_users_serch_without_admins() {
         [, $manager] = $this->setup_users();
-        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/_s/boost/core/1/u/f2';
+        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/boost/core/1/u/f2';
 
         $result = get_users::execute('Man', 'report/customsql:view');
-        $result = \external_api::clean_returnvalue(get_users::execute_returns(), $result);
+        $result = external_api::clean_returnvalue(get_users::execute_returns(), $result);
 
         $this->assertEquals([
                 [
@@ -161,10 +166,10 @@ class external_get_users_test extends \externallib_advanced_testcase {
 
     public function test_get_users_serch_with_admin() {
         [$admin] = $this->setup_users();
-        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/_s/boost/core/1/u/f2';
+        $defaultuserimage = 'https://www.example.com/moodle/theme/image.php/boost/core/1/u/f2';
 
         $result = get_users::execute('n U', 'report/customsql:view');
-        $result = \external_api::clean_returnvalue(get_users::execute_returns(), $result);
+        $result = external_api::clean_returnvalue(get_users::execute_returns(), $result);
 
         $this->assertEquals([
                 [


### PR DESCRIPTION
This fix for #141 and #140 solves some problems in report/customsql/tests/external/external_get_users_test.php

1. renaming namespace core_external
2. hardening the output $user->id as int
3. improve comparison $defaultuserimage
4. tests run in locked processes because moodle/site:config is loaded (output in the unit tests) 

Test instructions
* Run corresponding unit test --> no errors / comments