### PR TITLE
Feature: add limit query access to user list option

### DIFF
--- a/category.php
+++ b/category.php
@@ -37,6 +37,7 @@ $categoryid = required_param('id', PARAM_INT);
 $record = $DB->get_record('report_customsql_categories', ['id' => $categoryid], '*', MUST_EXIST);
 $queries = $DB->get_records('report_customsql_queries', ['categoryid' => $categoryid], 'displayname, id');
 
+$queries = \report_customsql\utils::filter_queries_by_visibility($queries, $context);
 $category = new \report_customsql\local\category($record);
 $category->load_queries_data($queries);
 $widget = new \report_customsql\output\category($category, $context);

--- a/classes/local/query.php
+++ b/classes/local/query.php
@@ -128,9 +128,22 @@ class query {
      * Check the capability to view the query.
      *
      * @param \context $context The context to check.
-     * @return bool Has capability to view or not?
+     * @return bool Has capability and access to view or not?
      */
-    public function can_view(\context $context):bool {
-        return empty($report->capability) || has_capability($report->capability, $context);
+    public function can_view(\context $context): bool {
+        global $USER;
+
+        $report = $this->record;
+
+        $hascapability = empty($report->capability) || has_capability($report->capability, $context);
+
+        if (!empty($report->useraccess) && !has_capability('moodle/site:config', $context)) {
+            $userids = explode(',', $report->useraccess);
+            $hasaccess = in_array($USER->id, $userids);
+        } else {
+            $hasaccess = true;
+        }
+
+        return $hascapability && $hasaccess;
     }
 }

--- a/classes/output/category.php
+++ b/classes/output/category.php
@@ -88,9 +88,6 @@ class category implements renderable, templatable {
             $queries = [];
             foreach ($querygroup['queries'] as $querydata) {
                 $query = new report_query($querydata);
-                if (!$query->can_view($this->context)) {
-                    continue;
-                }
                 $querywidget = new category_query($query, $this->category, $this->context, $this->returnurl);
                 $queries[] = ['categoryqueryitem' => $output->render($querywidget)];
             }

--- a/classes/output/index_page.php
+++ b/classes/output/index_page.php
@@ -71,6 +71,7 @@ class index_page implements renderable, templatable {
 
     public function export_for_template(renderer_base $output) {
         $categoriesdata = [];
+        $this->queries = utils::filter_queries_by_visibility($this->queries, $this->context);
         $grouppedqueries = utils::group_queries_by_category($this->queries);
         foreach ($this->categories as $record) {
             $category = new report_category($record);

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -140,6 +140,7 @@ class provider implements
                     $data['queryparams'] = $record->queryparams;
                     $data['querylimit'] = $record->querylimit;
                     $data['capability'] = $record->capability;
+                    $data['useraccess'] = $record->useraccess;
                     $data['lastrun'] = userdate($record->lastrun);
                     $data['lastexecutiontime'] = $record->lastexecutiontime;
                     $data['runable'] = $record->runable;

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -16,6 +16,8 @@
 
 namespace report_customsql;
 
+use report_customsql\local\query as report_query;
+
 /**
  * Static utility methods to support the report_customsql module.
  *
@@ -72,6 +74,20 @@ class utils {
     public static function get_number_of_report_by_type(array $queries, string $type) {
         return array_filter($queries, function($query) use ($type) {
             return $query->runable == $type;
+        }, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Filters out queries that are not visible.
+     *
+     * @param array $queries Array of queries.
+     * @param \context $context The context to check.
+     * @return array All queries the user can view.
+     */
+    public static function filter_queries_by_visibility(array $queries, \context $context) {
+        return array_filter($queries, function($querydata) use ($context) {
+            $query = new report_query($querydata);
+            return $query->can_view($context);
         }, ARRAY_FILTER_USE_BOTH);
     }
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -14,6 +14,7 @@
         <FIELD NAME="queryparams" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The SQL parameters to generate this report."/>
         <FIELD NAME="querylimit" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="5000" SEQUENCE="false" COMMENT="Limit the number of results returned."/>
         <FIELD NAME="capability" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="The capability that a user needs to have to run this report."/>
+        <FIELD NAME="useraccess" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="A comma-separated list of user ids that can run this report"/>
         <FIELD NAME="lastrun" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Timestamp of when this report was last run."/>
         <FIELD NAME="lastexecutiontime" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Time this report took to run last time it was executed, in milliseconds."/>
         <FIELD NAME="runable" TYPE="char" LENGTH="32" NOTNULL="true" DEFAULT="manual" SEQUENCE="false" COMMENT="'manual', 'weekly' or 'monthly'"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -269,5 +269,19 @@ function xmldb_report_customsql_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2021111600, 'report', 'customsql');
     }
 
+    if ($oldversion < 2024061900) {
+        // Define field useraccess to be added to report_customsql_queries.
+        $table = new xmldb_table('report_customsql_queries');
+        $field = new xmldb_field('useraccess', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, 'capability');
+
+        // Conditionally launch add field usermodified.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Customsql savepoint reached.
+        upgrade_plugin_savepoint(true, 2024061900, 'report', 'customsql');
+    }
+
     return true;
 }

--- a/edit.php
+++ b/edit.php
@@ -95,7 +95,13 @@ if ($newreport = $mform->get_data()) {
     $newreport->description = $newreport->description['text'];
 
     // Currently, autocomplete can return an empty value in the array. If we get one, strip it out.
+    $newreport->useraccess = trim(implode(',', $newreport->useraccess), ',');
     $newreport->emailto = trim(implode(',', $newreport->emailto), ',');
+
+    // Set the useraccess field to empty if the report capability is moodle/site:config.
+    if ($newreport->capability === 'moodle/site:config') {
+        $newreport->useraccess = '';
+    }
 
     // Set the following fields to empty strings if the report is running manually.
     if ($newreport->runable === 'manual') {

--- a/lang/en/report_customsql.php
+++ b/lang/en/report_customsql.php
@@ -90,6 +90,7 @@ $string['errordeletingcategory'] = '<p>Error deleting a query category.</p><p>It
 $string['errordeletingreport'] = 'Error deleting a query.';
 $string['errorinsertingreport'] = 'Error inserting a query.';
 $string['errorupdatingreport'] = 'Error updating a query.';
+$string['invalidaccess'] = 'Sorry, but you do not currently have access to this report.';
 $string['invalidreportid'] = 'Invalid query id {$a}.';
 $string['lastexecuted'] = 'This query was last run on {$a->lastrun}. It took {$a->lastexecutiontime}s to run.';
 $string['messageprovider:notification'] = 'Ad-hoc database query notifications';
@@ -183,6 +184,8 @@ $string['timecreated'] = '<span class="font-weight-bold">Time created:</span> {$
 $string['timemodified'] = '<span class="font-weight-bold">Last modified:</span> {$a}';
 $string['typeofresult'] = 'Type of result';
 $string['unknowndownloadfile'] = 'Unknown download file.';
+$string['useraccess'] = 'Limit query to';
+$string['useraccess_help'] = 'Limits access to this query to the selected users and administrators (moodle/site:config)';
 $string['usermodified'] = '<span class="font-weight-bold">Modified by:</span> {$a}';
 $string['usernotfound'] = 'User with id \'{$a}\' does not exist';
 $string['userhasnothiscapability'] = 'User \'{$a->name}\' ({$a->userid}) has not got capability \'{$a->capability}\'. Please delete this user from the list or change the choice in \'{$a->whocanaccess}\'.';

--- a/lib.php
+++ b/lib.php
@@ -44,7 +44,7 @@
  * @return bool false if file not found, does not return if found - just send the file
  */
 function report_customsql_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = []) {
-    global $DB;
+    global $DB, $USER;
 
     require_once(dirname(__FILE__) . '/locallib.php');
 
@@ -69,6 +69,13 @@ function report_customsql_pluginfile($course, $cm, $context, $filearea, $args, $
     $context = context_system::instance();
     if (!empty($report->capability)) {
         require_capability($report->capability, $context);
+    }
+
+    if (!empty($report->useraccess) && !has_capability('moodle/site:config', $context)) {
+        $userids = explode(',', $report->useraccess);
+        if (!in_array($USER->id, $userids)) {
+            throw new moodle_exception('invalidaccess', 'report_customsql');
+        }
     }
 
     $queryparams = report_customsql_get_query_placeholders_and_field_names($report->querysql);

--- a/locallib.php
+++ b/locallib.php
@@ -384,7 +384,7 @@ function report_customsql_get_reports_for($categoryid, $type) {
  * @param string $type, type of report (manual, daily, weekly or monthly)
  */
 function report_customsql_print_reports_for($reports, $type) {
-    global $OUTPUT;
+    global $OUTPUT, $USER;
 
     if (empty($reports)) {
         return;
@@ -401,6 +401,13 @@ function report_customsql_print_reports_for($reports, $type) {
     foreach ($reports as $report) {
         if (!empty($report->capability) && !has_capability($report->capability, $context)) {
             continue;
+        }
+
+        if (!empty($report->useraccess) && !has_capability('moodle/site:config', $context)) {
+            $userids = explode(',', $report->useraccess);
+            if (!in_array($USER->id, $userids)) {
+                continue;
+            }
         }
 
         echo html_writer::start_tag('p');

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023121300;
+$plugin->version   = 2024061900;
 $plugin->requires  = 2022112800;
 $plugin->component = 'report_customsql';
 $plugin->maturity  = MATURITY_STABLE;

--- a/view.php
+++ b/view.php
@@ -59,6 +59,13 @@ if (!empty($report->capability)) {
     require_capability($report->capability, $context);
 }
 
+if (!empty($report->useraccess) && !has_capability('moodle/site:config', $context)) {
+    $userids = explode(',', $report->useraccess);
+    if (!in_array($USER->id, $userids)) {
+        throw new moodle_exception('invalidaccess', 'report_customsql');
+    }
+}
+
 report_customsql_log_view($id);
 
 // We don't want slow reports blocking the session in other tabs.


### PR DESCRIPTION
It would be nice to have this feature added so that report visibility can be limited to a selected subset of users instead of all users with a capability.

The category counts were also not taking visibility into account, so this was fixed too.